### PR TITLE
[FIX] E7-S1 카테고리 조회 시 프론트엔드에서 urlPath를 받을 수 있도록 수정 #98

### DIFF
--- a/backend/src/main/java/com/infp/ciat/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/infp/ciat/category/controller/CategoryController.java
@@ -29,11 +29,12 @@ public class CategoryController {
     }
 
     @GetMapping("/categories")
-    public ResponseEntity<List<CategoryDto>> categoryList(@RequestParam Long menuId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+    public ResponseEntity<List<CategoryDto>> categoryList(@RequestParam String urlPath, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long accountId = getLoginedUserId(principalDetails);
 
-        return new ResponseEntity<>(categoryService.getList(menuId, accountId), HttpStatus.OK);
+        urlPath = urlPath.replace("\"", "");
+        return new ResponseEntity<>(categoryService.getList(urlPath, accountId), HttpStatus.OK);
     }
 
     @GetMapping("/category/{id}")

--- a/backend/src/main/java/com/infp/ciat/category/controller/dto/CategoryDto.java
+++ b/backend/src/main/java/com/infp/ciat/category/controller/dto/CategoryDto.java
@@ -17,6 +17,7 @@ public class CategoryDto {
     private String url;
     private Long orders;
     private Long menuId;
+    private String menuName;
 
     public CategoryDto(Category category) {
         this.id = category.getId();
@@ -26,10 +27,11 @@ public class CategoryDto {
         this.url = category.getUrl();
         this.orders = category.getOrders();
         this.menuId = category.getMenu().getId();
+        this.menuName = category.getMenu().getName();
     }
 
     @Builder
-    public CategoryDto(Long id,/* String uid,*/ String name, String icon, String url, Long orders, Long menuId) {
+    public CategoryDto(Long id,/* String uid,*/ String name, String icon, String url, Long orders, Long menuId, String menuName) {
         this.id = id;
 //        this.uid = uid;
         this.name = name;
@@ -37,6 +39,7 @@ public class CategoryDto {
         this.url = url;
         this.orders = orders;
         this.menuId = menuId;
+        this.menuName = menuName;
     }
 
 }

--- a/backend/src/main/java/com/infp/ciat/category/entity/Category.java
+++ b/backend/src/main/java/com/infp/ciat/category/entity/Category.java
@@ -68,6 +68,7 @@ public class Category extends BaseTimeEntity {
                 .url(url)
                 .orders(orders)
                 .menuId(menu.getId())
+                .menuName(menu.getName())
                 .build();
     }
 

--- a/backend/src/main/java/com/infp/ciat/category/repository/MenuRepository.java
+++ b/backend/src/main/java/com/infp/ciat/category/repository/MenuRepository.java
@@ -15,4 +15,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Query(nativeQuery = true, value = "SELECT * FROM menu WHERE id = :id AND show_yn = 'Y'")
     Optional<Menu> findByIdNotDeleted(@Param("id") Long id);
+
+    @Query(nativeQuery = true, value = "SELECT * FROM menu WHERE url = :url AND show_yn = 'Y'")
+    Optional<Menu> findByUrlNotDeleted(@Param("url") String url);
 }

--- a/backend/src/main/java/com/infp/ciat/category/service/CategoryService.java
+++ b/backend/src/main/java/com/infp/ciat/category/service/CategoryService.java
@@ -11,7 +11,7 @@ public interface CategoryService {
 
     CategoryDto create(CategorySaveRequestDto requestDto, Account account);
 
-    List<CategoryDto> getList(Long menuId, Long accountId);
+    List<CategoryDto> getList(String url, Long accountId);
 
     CategoryDto getDetail(Long categoryId, Long accountId);
 

--- a/backend/src/main/java/com/infp/ciat/category/service/CategoryServiceImpl.java
+++ b/backend/src/main/java/com/infp/ciat/category/service/CategoryServiceImpl.java
@@ -33,10 +33,11 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public List<CategoryDto> getList(Long menuId, Long accountId) {
+    public List<CategoryDto> getList(String url, Long accountId) {
 
         List<Category> categoryList;
 
+        Long menuId = menuRepository.findByUrlNotDeleted(url).get().getId();
         if ("식물관리".equals(menuRepository.findByIdNotDeleted(menuId).get().getName())) {
             categoryList = categoryRepository.findAllNotDeletedOnlyForPlantMenu(menuId, accountId);
         } else {


### PR DESCRIPTION
[x] 카테고리 조회 시 메뉴id 가 아닌 메뉴 url을 프론트엔드에서 받는 것으로 변경
[x] 카테고리를 return 할 때 카테고리가 속한 메뉴명까지 return하도록 변경